### PR TITLE
Enabled Custom Update Handlers

### DIFF
--- a/gum/gum.py
+++ b/gum/gum.py
@@ -121,7 +121,7 @@ class gum:
         self._loop_task: asyncio.Task | None = None
         self._batch_task: asyncio.Task | None = None
         self._batch_processing_lock = asyncio.Lock()
-        self.update_handlers: list[Callable[[Observer, Update], None]] = []
+        self.update_handlers: list[Callable[[Observer, Update], None]] = [self._default_handler]
 
     def start_update_loop(self):
         """Start the asynchronous update loop for processing observer updates."""
@@ -210,7 +210,8 @@ class gum:
                 upd: Update = fut.result()
                 obs = gets[fut]
 
-                asyncio.create_task(self._default_handler(obs, upd))
+                for handler in self.update_handlers:
+                    asyncio.create_task(handler(obs, upd))
 
     async def _batch_processing_loop(self):
         """Process batched observations when minimum batch size is reached."""


### PR DESCRIPTION
The existing GUM implementation had all of the scaffolding to enable custom update handlers, however in practice it was hardcoded to call only the default handler.  This PR ensures that all added update handlers are looped through and called, not just the default handler.  The default handler is still added to the list of handlers on initialization.