### PR TITLE
Enable Querying Recent Propositions

### DIFF
--- a/gum/db_utils.py
+++ b/gum/db_utils.py
@@ -288,3 +288,31 @@ async def get_recent_propositions(
 
     result = await session.execute(stmt)
     return result.scalars().all()
+
+
+async def get_recent_observations(
+    session: AsyncSession,
+    *,
+    limit: int = 10,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+) -> List[Observation]:
+    """Fetch the most recent observations ordered by created_at desc."""
+    if end_time is None:
+        end_time = datetime.now(timezone.utc)
+    if start_time is not None and start_time.tzinfo is None:
+        start_time = start_time.replace(tzinfo=timezone.utc)
+    if end_time.tzinfo is None:
+        end_time = end_time.replace(tzinfo=timezone.utc)
+
+    stmt = (
+        select(Observation)
+        .where(Observation.created_at <= end_time)
+        .order_by(Observation.created_at.desc())
+        .limit(limit)
+    )
+    if start_time is not None:
+        stmt = stmt.where(Observation.created_at >= start_time)
+
+    result = await session.execute(stmt)
+    return result.scalars().all()

--- a/gum/gum.py
+++ b/gum/gum.py
@@ -20,6 +20,7 @@ from sqlalchemy import insert
 from .db_utils import (
     get_related_observations,
     search_propositions_bm25,
+    get_recent_propositions,
 )
 from .models import Observation, Proposition, init_db
 from .observers import Observer
@@ -648,4 +649,22 @@ class gum:
                 mode=mode,
                 start_time=start_time,
                 end_time=end_time,
+            )
+
+    async def recent(
+        self,
+        *,
+        limit: int = 10,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        include_observations: bool = False,
+    ) -> list[Proposition]:
+        """Return the most recent propositions ordered by created_at descending."""
+        async with self._session() as session:
+            return await get_recent_propositions(
+                session,
+                limit=limit,
+                start_time=start_time,
+                end_time=end_time,
+                include_observations=include_observations,
             )

--- a/gum/gum.py
+++ b/gum/gum.py
@@ -21,6 +21,7 @@ from .db_utils import (
     get_related_observations,
     search_propositions_bm25,
     get_recent_propositions,
+    get_recent_observations,
 )
 from .models import Observation, Proposition, init_db
 from .observers import Observer
@@ -668,4 +669,20 @@ class gum:
                 start_time=start_time,
                 end_time=end_time,
                 include_observations=include_observations,
+            )
+
+    async def recent_observations(
+        self,
+        *,
+        limit: int = 10,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ) -> list[Observation]:
+        """Return the most recent observations ordered by created_at descending."""
+        async with self._session() as session:
+            return await get_recent_observations(
+                session,
+                limit=limit,
+                start_time=start_time,
+                end_time=end_time,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,7 @@ dependencies = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.0.0",
     "mkdocstrings>=0.24.0",
-    "mkdocstrings-python>=1.7.0",
-    "ics",
-    "aiohttp"
+    "mkdocstrings-python>=1.7.0"
 ]
 requires-python = ">=3.6"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.0.0",
     "mkdocstrings>=0.24.0",
-    "mkdocstrings-python>=1.7.0"
+    "mkdocstrings-python>=1.7.0",
+    "ics",
+    "aiohttp"
 ]
 requires-python = ">=3.6"
 


### PR DESCRIPTION
This pull request introduces a new feature to list the most recent propositions from the database, along with supporting changes to the CLI and backend. The main changes include adding a `--recent` or `-r` CLI flag, implementing the backend logic to fetch recent propositions, and updating the application flow to support this new mode.

**CLI and User Experience Improvements:**

* Added a `--recent` (`-r`) flag to the CLI in `gum/cli.py` to allow users to list the most recent propositions instead of running a BM25 search. The help message and argument parsing were updated accordingly.
* Updated the main CLI logic to support the new `--recent` mode, including user guidance and output formatting for recent propositions.

**Backend and Data Access Enhancements:**

* Implemented the `get_recent_propositions` async function in `gum/db_utils.py` to fetch the most recent propositions from the database, with options for limiting results and filtering by time range.
* Added a `recent` method to the `gum` class in `gum/gum.py` to expose the recent propositions functionality to the application layer.
* Imported the new `get_recent_propositions` function in `gum/gum.py` to enable its use in the `recent` method.